### PR TITLE
Support for use function and use const.

### DIFF
--- a/PHP Source.sublime-syntax
+++ b/PHP Source.sublime-syntax
@@ -382,9 +382,11 @@ contexts:
           pop: true
         - match: \\
           scope: punctuation.separator.inheritance.php
-    - match: (?i)\s*\b(use)\s+
+    - match: (?i)\s*\b(use)\s+(?:((const)|(function))\s+)?
       captures:
         1: keyword.other.use.php
+        3: storage.type.const.php
+        4: storage.type.function.php
       push:
         - meta_scope: meta.use.php
         - match: (?=;|(?:^\s*$))

--- a/PHP.tmLanguage
+++ b/PHP.tmLanguage
@@ -1279,13 +1279,23 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(?i)\s*\b(use)\s+</string>
+					<string>(?i)\s*\b(use)\s+(?:((const)|(function))\s+)?</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.use.php</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.const.php</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.php</string>
 						</dict>
 					</dict>
 					<key>end</key>


### PR DESCRIPTION
I can't take credit for this PR really, I just noticed `use function` and `use const` weren't working, and ported the relevant lines from [textmate/php.tmbundle](https://github.com/textmate/php.tmbundle).