### PR TITLE
Add support for characters between x7F-xFF in namespace identifiers.

### DIFF
--- a/PHP Source.sublime-syntax
+++ b/PHP Source.sublime-syntax
@@ -380,13 +380,13 @@ contexts:
             - include: namespace
             - match: "(?i)[a-z_][a-z_0-9]*"
               scope: entity.other.inherited-class.php
-    - match: '(?i)^\s*(namespace)\b\s+(?=([a-z0-9_\\]+\s*($|[;{]|(\/[\/*])))|$)'
+    - match: '(?i)^\s*(namespace)\b\s+(?=([a-z0-9\x{7f}-\x{ff}_\\]+\s*($|[;{]|(\/[\/*])))|$)'
       captures:
         1: keyword.other.namespace.php
       push:
         - meta_scope: meta.namespace.php
         - meta_content_scope: entity.name.type.namespace.php
-        - match: '(?i)(?=\s*$|[^a-z0-9_\\])'
+        - match: '(?i)(?=\s*$|[^a-z0-9\x{7f}-\x{ff}_\\])'
           pop: true
         - match: \\
           scope: punctuation.separator.inheritance.php


### PR DESCRIPTION
![before after namespace](https://cloud.githubusercontent.com/assets/11317458/14407382/66b2a112-fe9d-11e5-81a7-02a76dcb6072.jpg)
